### PR TITLE
Enable core plugins by default

### DIFF
--- a/jimmy.yaml
+++ b/jimmy.yaml
@@ -1,7 +1,10 @@
-include-default-plugins: false
+# Enable all core plugins (those included in the jimmy repository)
+include-default-plugins: true
 
-plugin-directories:
-  - ./plugins
+# list of paths for additional plugins
+#plugin-directories:
+#  - ./custom-plugins
+#  - /some/external/plugins
 
 defaults:
   inject:

--- a/tests/test_jim.py
+++ b/tests/test_jim.py
@@ -88,7 +88,7 @@ class TestJimmySchema(base.TestCase):
     def test_validation_fail_for_additional_properties(self):
         with open(jimmy_yaml_path, 'r') as f:
             jimmy_yaml = f.read()
-            mock_jimmy_yaml = jimmy_yaml.replace("plugin-directories:", "test:")
+            mock_jimmy_yaml = "\n".join([jimmy_yaml, "test:\n"])
         self.mfs = mockfs.replace_builtins()
         self.mfs.add_entries({jimmy_yaml_path: mock_jimmy_yaml,
                               jimmy_schema_path: self.jimmy_schema})


### PR DESCRIPTION
If jimmy is installed as a python package (fron PyPI) ./plugins folder
is not available when running 'jimmy' command.

Thus we enable loading default plugins, and leave explicit
setting plugin-directories for customized plugins only.

Also fix the test as it relied on the current jimmy.yaml structure.