### PR TITLE
Fix empty voting values in Gerrit Trigger

### DIFF
--- a/plugins/gerrit/resources/jenkins.groovy
+++ b/plugins/gerrit/resources/jenkins.groovy
@@ -17,8 +17,7 @@
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config
 import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer
 import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.BuildCancellationPolicy
 
 hostname = args[0]
 auth_key = args[1]
@@ -44,11 +43,12 @@ if (PluginImpl.getInstance().getServer(name) == null) {
   config = PluginImpl.getInstance().getServer(name).getConfig()
 }
 
-//buildCurrentPatchesOnly can be set only via JSON now
-def buildOnlyCurrent = [buildCurrentPatchesOnly: [abortNewPatchsets: false, abortManualPatchsets: false]]
-JSONObject currentPatchset = (JSONObject) JSONSerializer.toJSON(buildOnlyCurrent)
+BuildCancellationPolicy buildOnlyCurrent = new BuildCancellationPolicy()
+buildOnlyCurrent.enabled = true
+buildOnlyCurrent.abortNewPatchsets = true
+buildOnlyCurrent.abortManualPatchsets = true
 
-config.setValues(currentPatchset)
+config.buildCurrentPatchesOnly = buildOnlyCurrent
 config.setGerritHostName(hostname)
 config.setGerritFrontEndURL(url)
 config.setGerritUserName(username)


### PR DESCRIPTION
Create BuildCancellationPolicy object instead of passing JSONObject to
setValues() method. Using setValues() nullifies default voting values
when custom voting values are not supplied in JSON form.