### PR TITLE
Kubernetes Service Account credentials support

### DIFF
--- a/plugins/credentials/impl.py
+++ b/plugins/credentials/impl.py
@@ -12,6 +12,7 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
+import os
 import subprocess
 from lib.api import BaseGroovyPlugin
 
@@ -63,6 +64,28 @@ class Credentials(BaseGroovyPlugin):
                                      ], shell=False)
                 except OSError:
                     self.logger.exception('Could not find java')
+
+        if "kubernetes" in data:
+            kubernetes_groovy_path = os.path.join(
+                self.class_base_dir,
+                'resources/kubernetes.groovy'
+            )
+            for k in data["kubernetes"]:
+                description = k.get("description", "")
+                try:
+                    subprocess.call(["java",
+                                     "-jar", jenkins_cli_path,
+                                     "-s", jenkins_url,
+                                     "groovy",
+                                     kubernetes_groovy_path,
+                                     "updateCredentials",
+                                     k["scope"],
+                                     k["id"],
+                                     description
+                                     ], shell=False)
+                except OSError:
+                    self.logger.exception('Could not find java')
+
         if "token" in data:
             for t in data["token"]:
                 description = t.get("description", "")

--- a/plugins/credentials/resources/kubernetes.groovy
+++ b/plugins/credentials/resources/kubernetes.groovy
@@ -1,0 +1,80 @@
+/*
+*  Copyright 2017 Mirantis, Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License"); you may
+*  not use this file except in compliance with the License. You may obtain
+*  a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+*  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+*  License for the specific language governing permissions and limitations
+*  under the License.
+*/
+
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.domains.Domain
+import org.csanchez.jenkins.plugins.kubernetes.ServiceAccountCredential
+
+class Actions {
+  Actions(out) { this.out = out }
+  def out
+
+  void updateCredentials(String scope,
+                         String id,
+                         String description="") {
+
+    def globalDomain = Domain.global()
+    def credentialsStore =
+      Jenkins.instance.getExtensionList(
+        'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
+      )[0].getStore()
+
+    def credsScope
+    if (scope == "global") {
+      credsScope = CredentialsScope.GLOBAL
+    } else if (scope == "system") {
+      credsScope = CredentialsScope.SYSTEM
+    }
+
+    // Create or update the credentials in the Jenkins instance
+    def availableCredentials = CredentialsProvider.lookupCredentials(ServiceAccountCredential.class,
+                                                                    Jenkins.getInstance())
+    def existingCredentials
+
+    ServiceAccountCredential credentials = new ServiceAccountCredential(credsScope, id, description)
+
+    for (ServiceAccountCredential cred : availableCredentials) {
+      if (cred.id == id) {
+        existingCredentials = cred
+      }
+    }
+
+
+    if(existingCredentials != null) {
+      credentialsStore.updateCredentials(
+        globalDomain,
+        existingCredentials,
+        credentials
+      )
+    } else {
+      credentialsStore.addCredentials(globalDomain, credentials)
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// CLI Argument Processing
+///////////////////////////////////////////////////////////////////////////////
+
+actions = new Actions(out)
+action = args[0]
+if (args.length < 2) {
+  actions."$action"()
+} else {
+  actions."$action"(*args[1..-1])
+}

--- a/plugins/credentials/resources/schema.yaml
+++ b/plugins/credentials/resources/schema.yaml
@@ -88,6 +88,40 @@ properties:
       - username
       - private_key
 
+  kubernetes:
+    type: array
+    additionalItems: false
+    description: |
+      Read the OAuth bearer token from service account file provisioned by kubernetes
+      Service Account Admission Controller when Jenkins itself is deployed inside a Pod.
+    items:
+      type: object
+      properties:
+
+        id:
+          description: |
+            An internal unique ID by which these credentials are identified from jobs and other
+            configuration.
+          type: string
+
+        scope:
+          description: |
+            Global: Credentials discoverable by jobs and the Jenkins instance. Jobs can use those
+            credentials for e.g. SCP build artifacts, Jenkins for launching slave on the machine.
+            System: Credentials discoverable only by Jenkins instance for things like email auth,
+            slave connection, etc, i.e. where the Jenkins instance itself is using the credential.
+          enum: ['global', 'system']
+          type: string
+
+        description:
+          description: Credential description.
+          type: string
+
+      additionalProperties: false
+      required:
+      - id
+      - scope
+
   token:
     type: array
     additionalItems: false
@@ -134,3 +168,5 @@ anyOf:
   - ssh
 - required:
   - token
+- required:
+  - kubernetes

--- a/plugins/credentials/tests/test_credentials.py
+++ b/plugins/credentials/tests/test_credentials.py
@@ -65,6 +65,10 @@ class TestCredentialsPlugin(base.TestCase):
                                       '      username: user2',
                                       '      private_key: /home/user/.ssh/id_rsa',
                                       '      id: this-is-an-id',
+                                      '    kubernetes:',
+                                      '    - id: kubernetes-credentials',
+                                      '      scope: global',
+                                      '      description: kubernetes.example.com service creds',
                                       '    token:',
                                       '    - scope: global',
                                       '      username: user',
@@ -106,6 +110,15 @@ class TestCredentialsPlugin(base.TestCase):
                  call(['java',
                        '-jar', '<< path to jenkins-cli.jar >>',
                        '-s', 'http://localhost:8080', 'groovy',
+                       plugins_dir + '/' + 'credentials/resources/kubernetes.groovy',
+                       'updateCredentials',
+                       'global',
+                       'kubernetes-credentials',
+                       'kubernetes.example.com service creds'],
+                      shell=False),
+                 call(['java',
+                       '-jar', '<< path to jenkins-cli.jar >>',
+                       '-s', 'http://localhost:8080', 'groovy',
                        plugins_dir + '/' + 'credentials/resources/jenkins.groovy',
                        'updateCredentials',
                        "'global'",
@@ -116,7 +129,7 @@ class TestCredentialsPlugin(base.TestCase):
                        "'user-token'"],
                       shell=False)]
         mock_subp.assert_has_calls(calls, any_order=True)
-        assert 3 == mock_subp.call_count, "subprocess call should be equal to 3"
+        assert 4 == mock_subp.call_count, "subprocess call should be equal to 4"
 
 
 class TestCredentialsSchema(object):

--- a/sample/input/jenkins.yaml
+++ b/sample/input/jenkins.yaml
@@ -42,6 +42,10 @@ jenkins:
       description: SSH Username with private key entered directly
       private_key: !include-relative-text:
         secret/admin.key
+    kubernetes:
+    - scope: global
+      id: kubernetes-credentials
+      description: Kubernetes Service Account token
     token:
     - scope: global
       username: service-user


### PR DESCRIPTION
Add 'kubernetes' credentials type as an addition to kubernetes Jimmy
module. Correspoding groovy code is extracted to separate file to allow
usage of other credentials types without dependency on Kubernetes
Jenkins plugin.