### PR TITLE
Switch Travis CI to Trusty image (CI fix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: trusty
 python:
   - "2.7"
 before_install:


### PR DESCRIPTION
In absence of Xenial image Travis used Precise as a fallback (cool).
Since our only options for Travis are either Precise or trusty let's at
least explicitly use Trusty.